### PR TITLE
Add ComputerCraft Music Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ A note on abbreviations: `CC` is ComputerCraft, `CC:T` is ComputerCraft: Tweaked
 
 ### Tools
 
+- [ComputerCraft Music Converter](https://music.madefor.cc) - A web app to convert various sound formats to DFPWM (ComputerCraft's sound format).
 - [BIMG-Generator](https://github.com/MasonGulu/BIMG-Generator) - A Java program to convert images to the BIMG format.
 - [cc-tstl-template](https://github.com/MCJack123/cc-tstl-template) -  A template for the TypeScriptToLua compiler that allows writing ComputerCraft programs in TypeScript.
 - [sanjuuni](https://github.com/MCJack123/sanjuuni) -  A program to quickly convert image and video files into various formats for playback and streaming in ComputerCraft.


### PR DESCRIPTION
Add ComputerCraft Music Converter to Tools section.

- [x] I have read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I agree to release my contributions under the [CC-BY-SA](./LICENSE.md) license.
- [x] I have read the automated feedback from the spell-checker after submitting this pull request. <!-- Do not check this box when initially submitting your PR. -->

## Summary of changes

Added a link to ComputerCraft Music Converter web app, that converts various audio formats into DFPWM (ComputerCraft's audio format). The link was added to "Tools" section of the page.
