### PR TITLE
Add ShrekWord and ShrekPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ A note on abbreviations: `CC` is ComputerCraft, `CC:T` is ComputerCraft: Tweaked
 - [netshell](https://github.com/lyqyd/cc-netshell) -  Access a computer's shell from another computer.
 - [OrangeBox](https://github.com/walksanatora/orangebox) - Virtualization support for ComputerCraft computers.
 - [rawshell](https://gist.github.com/MCJack123/8c8861e5e3082d2bed18d07641b5b2cc) -  A modern alternative to netshell supporting CraftOS-PC's "raw mode" format, with file transfers, encryption, passwords, WebSockets, and more.
+- [ShrekPrint](https://pinestore.cc/projects/115/shrekprint) - Printing software with full color and book support.
+- [ShrekWord](https://pinestore.cc/projects/114/shrekword) - Word-like document editor.
 - [unicornpkg](https://unicornpkg.madefor.cc) -  Modern package management that doesn't suck.
 - [FSEncrypt](https://gist.github.com/MCJack123/32c56917dc61da336ec0e8ca6aae39f8) -  Transparent filesystem encryption.
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 awesome-computercraft contributors

SPDX-License-Identifier: CC-BY-SA-4.0
-->

- [x] I have read the [contribution guidelines](https://github.com/tomodachi94/awesome-computercraft/blob/main/CONTRIBUTING.md).
- [x] I agree to release my contributions under the [CC-BY-SA](https://github.com/tomodachi94/awesome-computercraft/blob/main/LICENSE.md) license.

## Summary of changes

<!-- Explain what was changed. -->
Add links to my programs ShrekWord and ShrekPrint. I think they belong on this list because they are the first programs of their type (to my knowledge). I'm only aware of one other attempt at a document editor, Ink, from way back in the day. It didn't support color printing *nor* autocrafting.

Not 100% whether these belong in "utility" or "fun," so if you think I made the wrong choice I'll move it over
